### PR TITLE
Important fixes for Workshop

### DIFF
--- a/bundler/webpack.dev.js
+++ b/bundler/webpack.dev.js
@@ -8,7 +8,8 @@ module.exports = webpackMerge(
         devServer:
         {
             contentBase: './dist',
-            open: true
+            open: true,
+            disableHostCheck: true
         }
     }
 )

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,9 @@ We, the GitHub Campus Club, are using this repository containing source code of 
 To run this project (_preview in developer mode_)
 
 ```bash
+# Install dependencies (only for first time)
+npm i
+
 # first run 
 export NODE_OPTIONS=--openssl-legacy-provider
 

--- a/readme.md
+++ b/readme.md
@@ -1,23 +1,14 @@
-# Folio 2019
+# GitHub Freshmen Workshop 2023
+## _GitHub Campus Club, **PSG College of Technology**_
 
-## Setup
-Download [Node.js](https://nodejs.org/en/download/).
-Run this followed commands:
+We, the GitHub Campus Club, are using this repository containing source code of [Bruno Simon](https://github.com/brunosimon/folio-2019) 's personal portfolio page for demonstration.
 
-``` bash
-# Just be sure that you've got parcel js on you system
-npm install -g parcel-bundler
+To run this project (_preview in developer mode_)
 
-# Install dependencies (only for first time)
-npm i
+```bash
+# first run 
+export NODE_OPTIONS=--openssl-legacy-provider
 
-# Serve at localhost:1234
+# then run
 npm run dev
-
-# Build for production in the dist/ directory
-npm run build
-```
-
-```
-🥚 2021eggpvlzscw
-```
+``` 


### PR DESCRIPTION
There were two issues in the repository, for our workshop.
They are not issues per se, just some tweaks needed for running this repository in our selected environment, GitPod.

1.  I get an `Invalid Host header` error, assuming that this repository was configured to run on the `bruno-simon.com` domain or  in `localhost`, but is made to run on GitPod's port forwarded URL. 
2. I also get another error, `ERR_OSSL_EVP_UNSUPPORTED`. This is because the OpenSSL version appears to be outdated. Updating the version of `node` does not help. Updating the `webpack` dependency rises a new error, `TypeError: Cannot add property htmlWebpackPluginAlterChunks`

Hence for problem 1, Host Checking is disabled in `bundler/webpack.dev.js` and for problem 2, the readme.md was updated with a `NODE_OPTIONS` bash command to use legacy OpenSSL

Plus the readme.md also has less important changes.